### PR TITLE
Add extensions resource and TTLs for re-fetching

### DIFF
--- a/APIs/SystemAPI.raml
+++ b/APIs/SystemAPI.raml
@@ -52,3 +52,12 @@ documentation:
         body:
           example: !include ../examples/global-get-200.json
           type: !include schemas/global.json
+/extensions:
+  displayName: Additional configuration resource
+  get:
+    description: Additional dynamic configuration parameters
+    responses:
+      200:
+        body:
+          example: !include ../examples/extensions-get-200.json
+          type: !include schemas/extensions.json

--- a/APIs/schemas/base.json
+++ b/APIs/schemas/base.json
@@ -6,10 +6,11 @@
   "items": {
     "type": "string",
     "enum": [
-      "global/"
+      "global/",
+      "extensions/"
     ],
-    "minItems": 1,
-    "maxItems": 1,
+    "minItems": 2,
+    "maxItems": 2,
     "uniqueItems": true
   }
 }

--- a/APIs/schemas/extensions.json
+++ b/APIs/schemas/extensions.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Defines further, potentially more dynamic configuration",
+  "title": "System resource - extensions",
+  "required": [
+    "ttl",
+    "extensions"
+  ],
+  "properties": {
+    "ttl": {
+      "description": "Frequency with which this resource may be re-checked",
+      "type": "integer",
+      "default": 3600,
+      "minimum": 1
+    },
+    "extensions": {
+      "type": "array",
+      "items": {
+      },
+      "minItems": 0,
+      "uniqueItems": true
+    }
+  }
+}

--- a/APIs/schemas/global.json
+++ b/APIs/schemas/global.json
@@ -8,11 +8,18 @@
     {
       "type": "object",
       "required": [
+        "ttl",
         "is04",
         "ptp"
       ],
       "additionalProperties": true,
       "properties": {
+        "ttl": {
+          "description": "Frequency with which this resource may be re-checked",
+          "type": "integer",
+          "default": 86400,
+          "minimum": 1
+        },
         "is04": {
           "description": "Constants relating to AMWA NMOS IS-04",
           "type": "object",

--- a/examples/base-get-200.json
+++ b/examples/base-get-200.json
@@ -1,3 +1,4 @@
 [
-    "global/"
+    "global/",
+    "extensions/"
 ]

--- a/examples/extensions-get-200.json
+++ b/examples/extensions-get-200.json
@@ -1,0 +1,18 @@
+{
+    "ttl": 3600,
+    "extensions": [
+        {
+            "type": "urn:x-nmos:system:global-example/v1.0",
+            "href": "http://eg.example.com:8888",
+            "params": {
+                "foo": "bar",
+                "baz": 42,
+                "qux": true
+            }
+        },
+        {
+            "type": "urn:x-nmos:system:syslog/v2.0",
+            "href": "syslogs://syslog.example.com:3477"
+        }
+    ]
+}

--- a/examples/global-get-200.json
+++ b/examples/global-get-200.json
@@ -4,15 +4,12 @@
     "label": "ZBQ System",
     "description": "System Global Information for ZBQ",
     "tags": {},
+    "ttl": 86400,
     "is04": {
         "heartbeat_interval": 8
     },
     "ptp": {
         "announce_receipt_timeout": 2,
         "domain_number": 57
-    },
-    "syslogv2": {
-        "hostname": "biglogger.ebu.ch",
-        "port": 3477
     }
 }


### PR DESCRIPTION
This adds two elements as discussed today.

First, the proposed mechanism to extend what config is surfaced is split into a separate API resource (/extensions). @garethsb-sony this will cross over with what you may have been looking at and may need editing. There is also a question over whether the lack of an ID/version in this resource is appropriate or not.

Second, a 'ttl' field is added to each resource to indicate how frequently a Node may re-poll the resource for changes.

All changes will require review by the group on the next call.