### PR TITLE
[v1.0 review] Some suggestions

### DIFF
--- a/APIs/SystemAPI.raml
+++ b/APIs/SystemAPI.raml
@@ -4,36 +4,18 @@
 # (c) AMWA 2018
 
 title: System
-baseUri: http://example.api.com/x-nmos/system/{version}
+baseUri: http://api.example.com/x-nmos/system/{version}
 version: v1.0
 mediaType: application/json
 
 documentation:
   - title: Overview
     content: |
-      The System API allows Nodes to obtain information that is common across a system
-  - title: DNS-SD Advertisement
+      The System API allows Nodes to obtain global configuration parameters that are common across the system
+  - title: Further Documentation
     content: |
-      System APIs MAY produce an mDNS advertisement of the type \_nmos-system.\_tcp. A unicast DNS announcement of the same type MAY be used in addition to or instead of using mDNS.
+      Further normative documentation covering the behaviour of this API is contained in the [docs](../docs) folder of this repository.
 
-      The IP address and port of the System API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.
-
-      Multiple DNS-SD advertisements for the same API are permitted where the API is exposed via multiple ports and/or protocols.
-
-  - title: DNS-SD TXT Records
-    content: |
-      **api\_proto**
-
-      The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_proto' with a value of either 'http' or 'https' dependent on the protocol in use by the System API web server.
-
-      **api\_ver**
-
-      The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_ver'. The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'. There should be no whitespace between commas, and versions should be listed in ascending order.
-
-      **pri**
-
-      The DNS-SD advertisement MUST include a TXT record with key 'pri' and an integer value. Servers MAY additionally represent a matching priority via the DNS-SD SRV record 'priority' and 'weight' as defined in RFC 2782. The TXT record should be used in favour to the SRV priority and weight where these values differ in order to overcome issues in the Bonjour and Avahi implementations.
-      Values 0 to 99 correspond to an active NMOS System API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system.
 /:
   displayName: Base
   get:

--- a/APIs/SystemAPI.raml
+++ b/APIs/SystemAPI.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 
-# AMWA NMOS System API
+# AMWA NMOS System Parameters Specification: System API
 # (c) AMWA 2018
 
 title: System

--- a/APIs/schemas/global.json
+++ b/APIs/schemas/global.json
@@ -21,7 +21,7 @@
           ],
           "properties": {
             "heartbeat_interval": {
-              "description": "How often a Node should re-assert its registration (in seconds)",
+              "description": "How often Nodes should perform a heartbeat to maintain their resources in the Registration API (in seconds)",
               "type": "integer",
               "default": 5,
               "minimum": 1,
@@ -30,7 +30,7 @@
           }
         },
         "ptp": {
-          "description": "Constants relating to IEEE1588 PTP",
+          "description": "Constants relating to PTP (IEEE 1588-2008 or later)",
           "type": "object",
           "required": [
             "announce_receipt_timeout",
@@ -57,12 +57,12 @@
           "additionalProperties": true,
           "properties": {
             "hostname": {
-              "description": "Hostname or IP of a syslog v2 server (optional)",
+              "description": "Hostname or IP address of a syslog v2 server (optional)",
               "type": "string",
               "format": "hostname"
             },
             "port": {
-              "description": "destination port number for syslog v2 messages",
+              "description": "Destination port number for syslog v2 messages",
               "type": "integer",
               "minimum": 1,
               "maximum": 65535
@@ -75,12 +75,12 @@
           "additionalProperties": true,
           "properties": {
             "hostname": {
-              "description": "Hostname or IP of a syslog v1 server (optional)",
+              "description": "Hostname or IP address of a syslog v1 server (optional)",
               "type": "string",
               "format": "hostname"
             },
             "port": {
-              "description": "destination port number for syslog v1 messages",
+              "description": "Destination port number for syslog v1 messages",
               "type": "integer",
               "minimum": 1,
               "maximum": 65535

--- a/APIs/schemas/global.json
+++ b/APIs/schemas/global.json
@@ -11,7 +11,6 @@
         "is04",
         "ptp"
       ],
-      "additionalProperties": true,
       "properties": {
         "is04": {
           "description": "Constants relating to AMWA NMOS IS-04",
@@ -54,7 +53,6 @@
         "syslogv2": {
           "description": "Constants relating to syslog v2 servers",
           "type": "object",
-          "additionalProperties": true,
           "properties": {
             "hostname": {
               "description": "Hostname or IP address of a syslog v2 server (optional)",
@@ -72,7 +70,6 @@
         "syslog": {
           "description": "Constants relating to syslog v1 servers",
           "type": "object",
-          "additionalProperties": true,
           "properties": {
             "hostname": {
               "description": "Hostname or IP address of a syslog v1 server (optional)",

--- a/APIs/schemas/global.json
+++ b/APIs/schemas/global.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "description": "Defines the Global System Constants",
-  "title": "System resource - globals",
+  "description": "Defines the global configuration parameters",
+  "title": "Global configuration resource",
   "allOf": [
     { "$ref": "resource_core.json" },
     {

--- a/APIs/schemas/global.json
+++ b/APIs/schemas/global.json
@@ -51,7 +51,7 @@
           }
         },
         "syslogv2": {
-          "description": "Constants relating to syslog v2 servers",
+          "description": "Constants relating to syslog v2 servers using TLS transport (IETF RFC 5424, RFC 5425)",
           "type": "object",
           "properties": {
             "hostname": {
@@ -64,7 +64,7 @@
               ]
             },
             "port": {
-              "description": "Destination port number for syslog v2 messages",
+              "description": "Destination port number for syslog v2 messages (default 6514)",
               "type": "integer",
               "minimum": 1,
               "maximum": 65535
@@ -72,7 +72,7 @@
           }
         },
         "syslog": {
-          "description": "Constants relating to syslog v1 servers",
+          "description": "Constants relating to syslog v1 servers using UDP transport (IETF RFC 5424, RFC 5426)",
           "type": "object",
           "properties": {
             "hostname": {
@@ -85,7 +85,7 @@
               ]
             },
             "port": {
-              "description": "Destination port number for syslog v1 messages",
+              "description": "Destination port number for syslog v1 messages (default 514)",
               "type": "integer",
               "minimum": 1,
               "maximum": 65535

--- a/APIs/schemas/global.json
+++ b/APIs/schemas/global.json
@@ -13,7 +13,7 @@
       ],
       "properties": {
         "is04": {
-          "description": "Constants relating to AMWA NMOS IS-04",
+          "description": "Constants relating to AMWA IS-04 NMOS Discovery and Registration",
           "type": "object",
           "required": [
             "heartbeat_interval"
@@ -55,9 +55,13 @@
           "type": "object",
           "properties": {
             "hostname": {
-              "description": "Hostname or IP address of a syslog v2 server (optional)",
+              "description": "Hostname or IP address of a syslog v2 server",
               "type": "string",
-              "format": "hostname"
+              "anyOf": [
+                {"format": "hostname"},
+                {"format": "ipv4"},
+                {"format": "ipv6"}
+              ]
             },
             "port": {
               "description": "Destination port number for syslog v2 messages",
@@ -72,9 +76,13 @@
           "type": "object",
           "properties": {
             "hostname": {
-              "description": "Hostname or IP address of a syslog v1 server (optional)",
+              "description": "Hostname or IP address of a syslog v1 server",
               "type": "string",
-              "format": "hostname"
+              "anyOf": [
+                {"format": "hostname"},
+                {"format": "ipv4"},
+                {"format": "ipv6"}
+              ]
             },
             "port": {
               "description": "Destination port number for syslog v1 messages",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# \[Work In Progress\] AMWA IS-09 NMOS System Specification
+# \[Work In Progress\] AMWA IS-09 NMOS System Parameters Specification
 
 The NMOS System API allows an NMOS Node (also known as a "Media Node") to obtain global configuration parameters that are common across the system.
 This enables the Node to start, or re-start, in a well defined way that is consistent with the environment it's running in.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,23 @@
-# \[Work In Progress\] AMWA IS-09 NMOS System API
+# \[Work In Progress\] AMWA IS-09 NMOS System Specification
 
-The NMOS System API allows an NMOS Node (also known as a "Media Node") to find Resources that are common across a system.
+The NMOS System API allows an NMOS Node (also known as a "Media Node") to obtain global configuration parameters that are common across the system.
 This enables the Node to start, or re-start, in a well defined way that is consistent with the environment it's running in.
 
 ## Getting started
 
 Readers are advised to be familiar with:
-*   The [JT-NM Reference Architecture](http://jt-nm.org/RA-1.0/)
-*   The [overview of Networked Media Open Specifications](https://github.com/AMWA-TV/nmos)
+* The [JT-NM Reference Architecture](http://jt-nm.org/RA-1.0/)
+* The [overview of Networked Media Open Specifications](https://amwa-tv.github.io/nmos)
 
 Readers should then read the [documentation](docs/) in this repository, and the [APIs](APIs/), which are written in RAML -- if a suitable tool is not available for reading this, then [this](APIs/generateHTML) will create HTML versions.
 
 > HTML rendered versions of all NMOS Specifications are available on the [NMOS GitHub pages](https://amwa-tv.github.io/nmos)
+
+## Releases
+
+It is recommended that the tagged releases are used as a reference for development as opposed to the 'master' or development branches of this repository.
+
+Each version of the specification is available under a v&lt;#MAJOR&gt;.&lt;#MINOR&gt; tag such as 'v1.0'. Once a specification has been released, any updates to its documentation and schemas which do not modify the specification will be made available via a v&lt;#MAJOR&gt;.&lt;#MINOR&gt;.&lt;#UPDATE&gt; tag such as 'v1.0.1'.
 
 ## Contents
 

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -1,4 +1,4 @@
-# AMWA NMOS System Resource API
+# AMWA NMOS System Specification: Overview
 
 _(c) AMWA 2018, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
@@ -8,18 +8,18 @@ The documents included in this directory provide additional details and recommen
 
 ## Introduction
 
-The purpose of this document is to explain the purpose of the NMOS System Resource and how an NMOS Node can access this.
+The purpose of this document is to explain the NMOS System API and how an NMOS Node can use this to obtain global configuration parameters that are common across the system.
 
 The terms 'Node', 'Device', 'Sender' and 'Receiver' will be used extensively throughout this document. Please refer to the core [NMOS Technical Overview](https://github.com/AMWA-TV/nmos/blob/master/NMOS%20Technical%20Overview.md) for definitions of these.
 
 ## API Definition
 
-The System API provides a single API resource via the path `/global`. This path is used to define global constants which apply to the system in which Nodes are deployed. With the exception of the System ID, these constants are defined within the schema for the global resource.
+The System API provides a single 'global configuration resource' via the path `/global`. This resource contains global configuration parameters which apply to the system in which Nodes are deployed.
 
 ### System ID
 
-The System ID is exposed via the `id` attribute of the `/global` resource. This is the ID of the system and is expected to be constant for the "life" of the system. This ID MUST be assigned randomly in each facility which deploys a System API.
+The System ID is exposed via the `id` attribute of the `/global` resource. This is the ID of the system and is expected to be constant for the "life" of the system. This ID MUST be assigned uniquely in each facility which deploys a System API.
 
 ## API Interaction
 
-The System API is provided such that Nodes can gather require configuration parameters at startup.  If the System API is not available, stored values from previous operation may be used.
+The System API is provided such that Nodes can obtain configuration parameters at startup. If the System API is not available, stored values from previous operation may be used.

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -1,4 +1,4 @@
-# AMWA NMOS System Specification: Overview
+# AMWA NMOS System Parameters Specification: Overview
 
 _(c) AMWA 2018, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 

--- a/docs/2.1. APIs - Common Keys.md
+++ b/docs/2.1. APIs - Common Keys.md
@@ -29,8 +29,7 @@ A set of keys and values providing a means to filter resources based on particul
 {
   "tags": {
     "location": ["Salford", "Media City"],
-    "studio": ["HQ1"],
-    "recording": ["The Voice UK"]
+    "studio": ["HQ1"]
   }
 }
 ```

--- a/docs/2.2. APIs - Client Side Implementation Notes.md
+++ b/docs/2.2. APIs - Client Side Implementation Notes.md
@@ -5,3 +5,7 @@ _(c) AMWA 2018, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 ## DNS-SD Bridging
 
 For clients which need to discover the services of a System API, but operate in software such as web browsers where DNS-SD is unsupported, it is suggested that a bridging service is employed to present the DNS-SD data via an HTTP service (or similar).
+
+## Empty Request Bodies
+
+A number of API resources specify HTTP requests with no request body (headers only). These commonly include HTTP GET, HEAD, OPTIONS and DELETE operations, but may include other HTTP methods in some circumstances. When performing API requests which have no specified request body schema, clients SHOULD NOT send any body payload and SHOULD NOT set the HTTP `Content-Type` header. Clients MAY set the `Content-Length` header to a value of `0` to indicate this empty body, but this is not mandated.

--- a/docs/2.3. APIs - Server Side Implementation Notes.md
+++ b/docs/2.3. APIs - Server Side Implementation Notes.md
@@ -4,11 +4,15 @@ _(c) AMWA 2018, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
 ## Cross-Origin Resource Sharing (CORS)
 
-In order to permit web control interfaces to be hosted remotely, all NMOS APIs MUST implement valid CORS HTTP headers in responses, and respond to HTTP pre-flight OPTIONS requests. In order to simplify development, the following headers may be returned in order to remove these restrictions as far as possible. Note that these are very relaxed and may not be suitable for a production deployment.
+In order to permit web-based control interfaces to be hosted remotely, all NMOS APIs MUST implement valid CORS HTTP headers in responses, and respond to HTTP pre-flight OPTIONS requests. In order to simplify development, the following headers may be returned in order to remove these restrictions as far as possible. Note that these are very relaxed and may not be suitable for a production deployment.
+
+In addition to this, where highlighted in the API specifications servers MUST respond to HTTP pre-flight OPTIONS requests. Servers MAY additionally support HTTP OPTIONS requests made to any other API resource.
+
+In order to simplify development, the following headers may be returned in order to remove these restrictions as far as possible. Note that these are very relaxed and may not be suitable for a production deployment.
 
 ```
 Access-Control-Allow-Origin: *
-Access-Control-Allow-Methods: GET, PUT, POST, HEAD, OPTIONS, DELETE
+Access-Control-Allow-Methods: GET, PUT, POST, PATCH, HEAD, OPTIONS, DELETE
 Access-Control-Allow-Headers: Content-Type, Accept
 Access-Control-Max-Age: 3600
 ```

--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -8,7 +8,21 @@ One DNS-SD service type is defined by this specification:
 
 * **_nmos-system._tcp:** A logical host which advertises a System API.
 
-Advertisements of the above type is accompanied by DNS TXT records as specified within the API RAML documentation.
+Advertisements of the above type are accompanied by DNS TXT records as specified within the following specification pages.
+
+## Unicast vs. Multicast DNS-SD
+
+Dependent on the architecture of a network, it may make sense to use one or both of unicast or multicast DNS for advertisement and discovery. The preferred method of advertisement is via unicast DNS-SD. Nodes may optionally be configured to support just one of unicast or multicast service discovery, however it is recommended that both are used by default in order to make initial device configuration as configuration free as possible.
+
+When performing a DNS-SD browse, clients should proceed as follows:
+
+1. Identify whether the client has been configured with DNS server addresses and a default search domain either manually or automatically via DHCP.
+2. If such configuration exists and the discovery mechanism is not explicitly set to mDNS, perform a unicast DNS browse for services of the required type via the search domain.
+3. If no unicast responses are received and the discovery mechanism is not explicitly set to unicast DNS, perform a multicast DNS browse for services of the required type in the '.local' domain.
+   * Note that if a unicast response is received, multicast browsing should not be performed even if the unicast-discovered API is unresponsive.
+4. Where both unicast and multicast DNS are used, merge the results of the above operations into a single list.
+5. Sort the list of discovered services using the priority values associated with each record, and discard any advertisements which do not meet the Node's requirements.
+6. The above list should be maintained via the methods defined by the DNS-SD specification.
 
 ## Implementation Notes
 

--- a/docs/3.1. Discovery - Operation.md
+++ b/docs/3.1. Discovery - Operation.md
@@ -1,0 +1,42 @@
+# Discovery: Operation
+
+_(c) AMWA 2020, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
+
+This document describes usage of DNS-SD records for discovery in more detail.
+
+## System API
+
+### DNS-SD Advertisement
+
+The preferred method of System API advertisement is via unicast DNS-SD advertisement of the type \_nmos-system.\_tcp. System APIs MUST additionally be capable of producing an mDNS advertisement. This MAY be disabled via a user-configurable method.
+
+The IP address and port of the System API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.
+
+Multiple DNS-SD advertisements for the same API are permitted where the API is exposed via multiple ports and/or protocols.
+
+### DNS-SD TXT Records
+
+**api\_proto**
+
+The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_proto' with a value of either 'http' or 'https' dependent on the protocol in use by the Registration API web server.
+
+**api\_ver**
+
+The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_ver'. The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'. There should be no whitespace between commas, and versions should be listed in ascending order.
+
+**pri**
+
+The DNS-SD advertisement MUST include a TXT record with key 'pri' and an integer value. Servers MAY additionally represent a matching priority via the DNS-SD SRV record 'priority' and 'weight' as defined in RFC 2782. The TXT record should be used in favour to the SRV priority and weight where these values differ in order to overcome issues in the Bonjour and Avahi implementations.
+Values 0 to 99 correspond to an active NMOS System API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system.
+
+### Client Interaction Procedure
+
+1. Node comes online
+2. Node scans for an active System API on the network using unicast and/or multicast DNS service discovery (type '\_nmos-system.\_tcp') as described in the [Discovery](3.0.%20Discovery.md#unicast-vs-multicast-dns-sd) document.
+3. Given multiple returned System APIs, the Node orders these based on their advertised priority (TXT pri), filtering out any APIs which do not support its required API version and protocol (TXT api_ver and api_proto).
+4. The Node selects a System API to use based on the priority, and a random selection if multiple System APIs of the same API version with the same priority are identified.
+5. Node proceeds to fetch the global configuration resource.
+
+If the chosen System API does not respond correctly, another System API should be selected from the discovered list. Should no further System APIs be available or TTLs on advertised services expired, a re-query may be performed.
+
+If no System APIs are advertised on a network, the Node may use stored values from previous operation.


### PR DESCRIPTION
* Move DNS-SD TXT record info out of RAML into new 3.1 (as recently done for IS-04, etc.)
* Use 'global configuration resource' and 'global configuration parameters' consistently
* Specify that the System ID MUST be assigned 'uniquely' rather than 'randomly'
* Sync 2.2 with IS-04 (adds Empty Request Bodies clarification)
* Sync 2.3 with IS-04 (adds clarification on CORS/OPTIONS requests)
* Use api.example.com rather than example.api.com, since api.com is registered to GE Healthcare Life Sciences, now Cytiva, whereas example.com is provided for this purpose.
* Fix several typos.
* Tweak "tags" example since a System API for a particular recording seems unlikely, so it was a bit confusing?

I will base a PR to clarify the Node interaction with the System API at start-up on top of this.