### PR TITLE
Added ToC to long docs

### DIFF
--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -1,4 +1,8 @@
 # APIs
+{:.no_toc}
+
+* A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
 
 _(c) AMWA 2018, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 


### PR DESCRIPTION
In this case only the APIs doc was long enough to warrant this.